### PR TITLE
add installed LaTex packages in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,18 @@ RUN  apt-get update \
   && apt-get install -y --no-install-recommends \
      libv8-dev
 
+## Install tinytex
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    r-cran-tinytex
+RUN  Rscript -e 'tinytex::install_tinytex(force = TRUE)'
+
+## Install LaTeX packages
+RUN apt-get update \
+  && apt-get install -y  --no-install-recommends \
+    ghostscript \
+  && Rscript -e 'tinytex::tlmgr_install(c("amsmath", "amssymb", "array", "babel-dutch", "babel-english", "babel-french", "beamer", "beamerarticle", "biblatex", "bookmark", "booktabs", "calc", "caption", "csquotes", "dvips", "etoolbox", "fancyvrb", "fontenc", "fontspec", "footnote", "footnotehyper", "geometry", "graphicx", "helvetic", "hyperref", "hyphen-dutch", "hyphen-french", "iftex", "inconsolata", "inputenc", "listings", "lmodern", "longtable", "luatexja-preset", "luatexja-fontspec", "mathspec", "microtype", "multirow", "natbib", "orcidlink", "parskip", "pgfpages", "selnolig", "setspace", "soul", "svg", "tex", "textcomp", "times", "unicode-math", "upquote", "url", "xcolor", "xeCJK", "xurl"))'
+
 WORKDIR /github/workspace
 
 RUN R -e "install.packages('renv', repos = c(CRAN = 'https://cloud.r-project.org'))"


### PR DESCRIPTION
## Description

This PR aims to install the LaTex packages in the docker image to have a more stable docker image with everything included (no external installations needed).

The now proposed PR causes problems during docker image build, because the in renv specified MASS R package cannot be installed on Ubuntu 22.4 (which is in the rocker/verse latest image).  So either renv should be updated, or an earlier version of rocker/verse should be used before merging this PR.
