### PR TITLE
allow renv::restore to retrieve source versions

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,6 @@
 source("renv/activate.R")
+local({
+  options(
+    pkgType = "both"
+  )
+})


### PR DESCRIPTION
overwrite an option from Rprofile.site via .Rprofile