### PR TITLE
Update GHA that publishes website

### DIFF
--- a/.github/workflows/update_website.yml
+++ b/.github/workflows/update_website.yml
@@ -11,8 +11,13 @@ jobs:
     name: "add protocol to website"
     steps:
       - name: lookup branch name
-        uses: actions/checkout@v2
-      - uses: tonynguyenit18/github-action-custom-vars@v1
+        uses: actions/checkout@v4
+        with:
+          fetch-dept: 2
+      - name: Get branch name of latest merged PR targeting main
+        run: |
+          RECENT_MERGED_BRANCH_NAME=$(git log --merges origin/main --oneline --grep='^Merge' -1 | grep -oe 'inbo/.*$' | awk -F '/' '{print $2}')
+          echo "RECENT_MERGED_BRANCH_NAME=$RECENT_MERGED_BRANCH_NAME" >> $GITHUB_ENV
       - name: test
         run: echo 'branch name =' $RECENT_MERGED_BRANCH_NAME
       - name: Checkout repo and build website

--- a/.github/workflows/update_website.yml
+++ b/.github/workflows/update_website.yml
@@ -1,4 +1,4 @@
-name: On merge of "Log RECENT_MERGED_BRANCH_NAME" to main, build the protocol and add it to the website
+name: On merge of protocol branch to main, build the protocol and add it to the website
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "add protocol to website"
     steps:
-      - name: lookup branch name
+      - name: checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-dept: 2


### PR DESCRIPTION
## Description

This PR replaces an old external GHA by own code for retrieving the branch name of a recently merged branch to avoid the deprecation notes described in issue #111.

## Task list

<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists for an explanation on how to use task lists-->

Steps by contributor:

-   [x] Add description to this pull request (under "## Description")
-   [x] Mark the pull request as 'ready for review'

Review steps for the author(s):

-   [x] Add reviewers, at least one subject-matter specialist and one administrator
-   [ ] Wait for review comments and address them
-   [ ] Iterate until reviewer approvals (merging the pull request will be done by an administrator)
-   [ ] Verify that the checks done by continuous integration succeeded. These will check if `protocolhelper::check_frontmatter()` and `protocolhelper::check_structure()` succeeded without errors.

To be done by an administrator after review: see [guidelines for admins](https://github.com/inbo/protocolsource/blob/main/RELEASES.md).
